### PR TITLE
Adds pfcptest/analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,8 @@ pfcp/pfcpr15/*.a
 pfcp/pfcpr15/st*
 pfcp/src/.deps
 pfcp/pfcptest/.deps
+pfcp/pfcptest/analysis/.deps
+pfcp/pfcptest/analysis/.dirstamp
 pfcp/pfcptest/pcaps/.deps
 pfcp/pfcptest/pcaps/.dirstamp
 pfcp/pfcptest/pfcptest

--- a/include/epc/ejsonbuilder.h
+++ b/include/epc/ejsonbuilder.h
@@ -68,6 +68,7 @@ public:
 
     using StackString = StackValue<EString>;
     using StackUInt = StackValue<UInt>;
+    using StackULongLong = StackValue<ULongLong>;
     using StackBool = StackValue<Bool>;
 
     /// @brief A helper class which pushes/pops items on the builder's 
@@ -105,7 +106,15 @@ public:
 
     /// @brief Pushes an unsigned integer value onto the stack
     /// @param value the value of the unsigned integer object
-    Void push(const UInt value);
+    Void push(UInt value);
+
+    /// @brief Pushes an unsigned integer value onto the stack
+    /// @param value the value of the unsigned integer object
+    Void push(ULongLong value);
+
+    /// @brief Pushes an bool value onto the stack
+    /// @param value the value of the bool object
+    Void push(Bool value);
 
     /// @brief Pops the top object off the stack.
     /// @param name the name to use when adding this object to a container object 

--- a/include/epc/pfcpr15.h
+++ b/include/epc/pfcpr15.h
@@ -4631,6 +4631,7 @@ public:
    uint16_t length() const;
    ApplicationIdsPfdsIE &app_ids_pfds(uint8_t idx);
    int next_app_ids_pfds();
+   uint8_t app_ids_pfds_count() const;
    PfdMgmtReq &encode(uint8_t *dest);
    pfcp_pfd_mgmt_req_t &data();
    CLASS_NAME
@@ -4689,6 +4690,7 @@ public:
    CpFunctionFeaturesIE &cp_func_feat(Bool forceInit = False);
    UserPlaneIpResourceInformationIE &user_plane_ip_rsrc_info(uint8_t idx);
    int next_user_plane_ip_rsrc_info();
+   uint8_t user_plane_ip_rsrc_info_count() const;
    AssnSetupReq &encode(uint8_t *dest);
    pfcp_assn_setup_req_t &data();
    CLASS_NAME
@@ -4724,6 +4726,7 @@ public:
    CpFunctionFeaturesIE &cp_func_feat(Bool forceInit = False);
    UserPlaneIpResourceInformationIE &user_plane_ip_rsrc_info(uint8_t idx);
    int next_user_plane_ip_rsrc_info();
+   uint8_t user_plane_ip_rsrc_info_count() const;
    AssnSetupRsp &encode(uint8_t *dest);
    pfcp_assn_setup_rsp_t &data();
    CLASS_NAME
@@ -4759,6 +4762,7 @@ public:
    GracefulReleasePeriodIE &graceful_rel_period(Bool forceInit = False);
    UserPlaneIpResourceInformationIE &user_plane_ip_rsrc_info(uint8_t idx);
    int next_user_plane_ip_rsrc_info();
+   uint8_t user_plane_ip_rsrc_info_count() const;
    AssnUpdateReq &encode(uint8_t *dest);
    pfcp_assn_upd_req_t &data();
    CLASS_NAME
@@ -5036,6 +5040,11 @@ public:
    int next_create_urr();
    int next_create_qer();
    int next_create_traffic_endpt();
+   uint8_t create_pdr_count() const;
+   uint8_t create_far_count() const;
+   uint8_t create_urr_count() const;
+   uint8_t create_qer_count() const;
+   uint8_t create_traffic_endpt_count() const;
    SessionEstablishmentReq &encode(uint8_t *dest);
    pfcp_sess_estab_req_t &data();
    CLASS_NAME
@@ -5083,6 +5092,8 @@ public:
    CreatedTrafficEndpointIE &created_traffic_endpt(uint8_t idx);
    int next_created_pdr();
    int next_created_traffic_endpt();
+   uint8_t created_pdr_count() const;
+   uint8_t created_traffic_endpt_count() const;
    SessionEstablishmentRsp &encode(uint8_t *dest);
    pfcp_sess_estab_rsp_t &data();
    CLASS_NAME
@@ -5165,6 +5176,19 @@ public:
    int next_update_urr();
    int next_update_qer();
    int next_query_urr();
+   uint8_t remove_pdr_count() const;
+   uint8_t remove_far_count() const;
+   uint8_t remove_urr_count() const;
+   uint8_t remove_qer_count() const;
+   uint8_t create_pdr_count() const;
+   uint8_t create_far_count() const;
+   uint8_t create_urr_count() const;
+   uint8_t create_qer_count() const;
+   uint8_t update_pdr_count() const;
+   uint8_t update_far_count() const;
+   uint8_t update_urr_count() const;
+   uint8_t update_qer_count() const;
+   uint8_t query_urr_count() const;
    SessionModificationReq &encode(uint8_t *dest);
    pfcp_sess_mod_req_t &data();
    CLASS_NAME
@@ -5218,6 +5242,7 @@ public:
    CreatedTrafficEndpointIE &createdupdated_traffic_endpt(Bool forceInit = False);
    UsageReportSessionModificationRspIE &usage_report(uint8_t idx);
    int next_usage_report();
+   uint8_t usage_report_count() const;
    SessionModificationRsp &encode(uint8_t *dest);
    pfcp_sess_mod_rsp_t &data();
    CLASS_NAME
@@ -5266,6 +5291,7 @@ public:
    OverloadControlInformationIE &ovrld_ctl_info(Bool forceInit = False);
    UsageReportSessionDeletionRspIE &usage_report(uint8_t idx);
    int next_usage_report();
+   uint8_t usage_report_count() const;
    SessionDeletionRsp &encode(uint8_t *dest);
    pfcp_sess_del_rsp_t &data();
    CLASS_NAME
@@ -5303,6 +5329,7 @@ public:
    AdditionalUsageReportsInformationIE &add_usage_rpts_info(Bool forceInit = False);
    UsageReportSessionReportReqIE &usage_report(uint8_t idx);
    int next_usage_report();
+   uint8_t usage_report_count() const;
    SessionReportReq &encode(uint8_t *dest);
    pfcp_sess_rpt_req_t &data();
    CLASS_NAME

--- a/include/epc/pfcpr15inl.h
+++ b/include/epc/pfcpr15inl.h
@@ -9746,6 +9746,11 @@ inline int PfdMgmtReq::next_app_ids_pfds()
       data_.app_ids_pfds_count++ : -1;
 }
 
+inline uint8_t PfdMgmtReq::app_ids_pfds_count() const
+{
+   return data_.app_ids_pfds_count;
+}
+
 inline PfdMgmtReq &PfdMgmtReq::encode(uint8_t *dest)
 {
    data_.header.seid_seqno.no_seid.seq_no = seqNbr();
@@ -9762,14 +9767,6 @@ inline pfcp_pfd_mgmt_req_t &PfdMgmtReq::data()
 
 inline Void PfdMgmtReq::postDecode()
 {
-   for (int i=0; i<MAX_LIST_SIZE; i++)
-   {
-      if (data_.app_ids_pfds[i].header.len > 0)
-      {
-         next_app_ids_pfds();
-         app_ids_pfds(i);
-      }
-   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -9881,6 +9878,11 @@ inline int AssnSetupReq::next_user_plane_ip_rsrc_info()
       data_.user_plane_ip_rsrc_info_count++ : -1;
 }
 
+inline uint8_t AssnSetupReq::user_plane_ip_rsrc_info_count() const
+{
+   return data_.user_plane_ip_rsrc_info_count;
+}
+
 inline AssnSetupReq &AssnSetupReq::encode(uint8_t *dest)
 {
    data_.header.seid_seqno.no_seid.seq_no = seqNbr();
@@ -9901,11 +9903,6 @@ inline Void AssnSetupReq::postDecode()
    if (data_.rcvry_time_stmp.header.len > 0)          rcvry_time_stmp(True);
    if (data_.up_func_feat.header.len > 0)             up_func_feat(True);
    if (data_.cp_func_feat.header.len > 0)             cp_func_feat(True);
-
-   for (int i=0; i<MAX_LIST_SIZE; i++)
-   {
-      if (data_.user_plane_ip_rsrc_info[i].header.len > 0) { next_user_plane_ip_rsrc_info(); user_plane_ip_rsrc_info(i); }
-   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -9974,6 +9971,11 @@ inline int AssnSetupRsp::next_user_plane_ip_rsrc_info()
       data_.user_plane_ip_rsrc_info_count++ : -1;
 }
 
+inline uint8_t AssnSetupRsp::user_plane_ip_rsrc_info_count() const
+{
+   return data_.user_plane_ip_rsrc_info_count;
+}
+
 inline AssnSetupRsp &AssnSetupRsp::encode(uint8_t *dest)
 {
    data_.header.seid_seqno.no_seid.seq_no = req()->seqNbr();
@@ -9995,11 +9997,6 @@ inline Void AssnSetupRsp::postDecode()
    if (data_.rcvry_time_stmp.header.len > 0)          rcvry_time_stmp(True);
    if (data_.up_func_feat.header.len > 0)             up_func_feat(True);
    if (data_.cp_func_feat.header.len > 0)             cp_func_feat(True);
-
-   for (int i=0; i<MAX_LIST_SIZE; i++)
-   {
-      if (data_.user_plane_ip_rsrc_info[i].header.len > 0) { next_user_plane_ip_rsrc_info(); user_plane_ip_rsrc_info(i); }
-   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -10069,6 +10066,11 @@ inline int AssnUpdateReq::next_user_plane_ip_rsrc_info()
       data_.user_plane_ip_rsrc_info_count++ : -1;
 }
 
+inline uint8_t AssnUpdateReq::user_plane_ip_rsrc_info_count() const
+{
+   return data_.user_plane_ip_rsrc_info_count;
+}
+
 inline AssnUpdateReq &AssnUpdateReq::encode(uint8_t *dest)
 {
    data_.header.seid_seqno.no_seid.seq_no = seqNbr();
@@ -10090,11 +10092,6 @@ inline Void AssnUpdateReq::postDecode()
    if (data_.cp_func_feat.header.len > 0)             cp_func_feat(True);
    if (data_.up_assn_rel_req.header.len > 0)          up_assn_rel_req(True);
    if (data_.graceful_rel_period.header.len > 0)      graceful_rel_period(True);
-
-   for (int i=0; i<MAX_LIST_SIZE; i++)
-   {
-      if (data_.user_plane_ip_rsrc_info[i].header.len > 0) { next_user_plane_ip_rsrc_info(); user_plane_ip_rsrc_info(i); }
-   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -10732,6 +10729,31 @@ inline int SessionEstablishmentReq::next_create_traffic_endpt()
       data_.create_traffic_endpt_count++ : -1;
 }
 
+inline uint8_t SessionEstablishmentReq::create_pdr_count() const
+{
+   return data_.create_pdr_count;
+}
+
+inline uint8_t SessionEstablishmentReq::create_far_count() const
+{
+   return data_.create_far_count;
+}
+
+inline uint8_t SessionEstablishmentReq::create_urr_count() const
+{
+   return data_.create_urr_count;
+}
+
+inline uint8_t SessionEstablishmentReq::create_qer_count() const
+{
+   return data_.create_qer_count;
+}
+
+inline uint8_t SessionEstablishmentReq::create_traffic_endpt_count() const
+{
+   return data_.create_traffic_endpt_count;
+}
+
 inline SessionEstablishmentReq &SessionEstablishmentReq::encode(uint8_t *dest)
 {
    data_.header.seid_seqno.has_seid.seq_no = seqNbr();
@@ -10762,15 +10784,6 @@ inline Void SessionEstablishmentReq::postDecode()
    if (data_.user_id.header.len > 0)                  user_id(True);
    if (data_.trc_info.header.len > 0)                 trc_info(True);
    if (data_.apn_dnn.header.len > 0)                  apn_dnn(True);
-
-   // for (int i=0; i<MAX_LIST_SIZE; i++)
-   // {
-   //    if (data_.create_pdr[i].header.len > 0)            { next_create_pdr(); create_pdr(i); }
-   //    if (data_.create_far[i].header.len > 0)            { next_create_far(); create_far(i); }
-   //    if (data_.create_urr[i].header.len > 0)            { next_create_urr(); create_urr(i); }
-   //    if (data_.create_qer[i].header.len > 0)            { next_create_qer(); create_qer(i); }
-   //    if (data_.create_traffic_endpt[i].header.len > 0)  { next_create_traffic_endpt(); create_traffic_endpt(i); }
-   // }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -10877,6 +10890,16 @@ inline int SessionEstablishmentRsp::next_created_traffic_endpt()
       data_.created_traffic_endpt_count++ : -1;
 }
 
+inline uint8_t SessionEstablishmentRsp::created_pdr_count() const
+{
+   return data_.created_pdr_count;
+}
+
+inline uint8_t SessionEstablishmentRsp::created_traffic_endpt_count() const
+{
+   return data_.created_traffic_endpt_count;
+}
+
 inline SessionEstablishmentRsp &SessionEstablishmentRsp::encode(uint8_t *dest)
 {
    data_.header.seid_seqno.has_seid.seq_no = req()->seqNbr();
@@ -10902,12 +10925,6 @@ inline Void SessionEstablishmentRsp::postDecode()
    if (data_.ovrld_ctl_info.header.len > 0)           ovrld_ctl_info(True);
    if (data_.up_fqcsid.header.len > 0)                up_fqcsid(True);
    if (data_.failed_rule_id.header.len > 0)           failed_rule_id(True);
-
-   for (int i=0; i<MAX_LIST_SIZE; i++)
-   {
-      if (data_.created_pdr[i].header.len > 0)           { next_created_pdr(); created_pdr(i); }
-      if (data_.created_traffic_endpt[i].header.len > 0) { next_created_traffic_endpt(); created_traffic_endpt(i); }
-   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -11247,6 +11264,71 @@ inline int SessionModificationReq::next_query_urr()
       data_.query_urr_count++ : -1;
 }
 
+inline uint8_t SessionModificationReq::remove_pdr_count() const
+{
+   return data_.remove_pdr_count;
+}
+
+inline uint8_t SessionModificationReq::remove_far_count() const
+{
+   return data_.remove_far_count;
+}
+
+inline uint8_t SessionModificationReq::remove_urr_count() const
+{
+   return data_.remove_urr_count;
+}
+
+inline uint8_t SessionModificationReq::remove_qer_count() const
+{
+   return data_.remove_qer_count;
+}
+
+inline uint8_t SessionModificationReq::create_pdr_count() const
+{
+   return data_.create_pdr_count;
+}
+
+inline uint8_t SessionModificationReq::create_far_count() const
+{
+   return data_.create_far_count;
+}
+
+inline uint8_t SessionModificationReq::create_urr_count() const
+{
+   return data_.create_urr_count;
+}
+
+inline uint8_t SessionModificationReq::create_qer_count() const
+{
+   return data_.create_qer_count;
+}
+
+inline uint8_t SessionModificationReq::update_pdr_count() const
+{
+   return data_.update_pdr_count;
+}
+
+inline uint8_t SessionModificationReq::update_far_count() const
+{
+   return data_.update_far_count;
+}
+
+inline uint8_t SessionModificationReq::update_urr_count() const
+{
+   return data_.update_urr_count;
+}
+
+inline uint8_t SessionModificationReq::update_qer_count() const
+{
+   return data_.update_qer_count;
+}
+
+inline uint8_t SessionModificationReq::query_urr_count() const
+{
+   return data_.query_urr_count;
+}
+
 inline SessionModificationReq &SessionModificationReq::encode(uint8_t *dest)
 {
    data_.header.seid_seqno.has_seid.seq_no = seqNbr();
@@ -11280,23 +11362,6 @@ inline Void SessionModificationReq::postDecode()
    if (data_.user_plane_inact_timer.header.len > 0)   user_plane_inact_timer(True);
    if (data_.query_urr_ref.header.len > 0)            query_urr_ref(True);
    if (data_.trc_info.header.len > 0)                 trc_info(True);
-
-   for (int i=0; i<MAX_LIST_SIZE; i++)
-   {
-      if (data_.remove_pdr[i].header.len > 0)   { next_remove_pdr(); remove_pdr(i); }
-      if (data_.remove_far[i].header.len > 0)   { next_remove_far(); remove_far(i); }
-      if (data_.remove_urr[i].header.len > 0)   { next_remove_urr(); remove_urr(i); }
-      if (data_.remove_qer[i].header.len > 0)   { next_remove_qer(); remove_qer(i); }
-      if (data_.create_pdr[i].header.len > 0)   { next_create_pdr(); create_pdr(i); }
-      if (data_.create_far[i].header.len > 0)   { next_create_far(); create_far(i); }
-      if (data_.create_urr[i].header.len > 0)   { next_create_urr(); create_urr(i); }
-      if (data_.create_qer[i].header.len > 0)   { next_create_qer(); create_qer(i); }
-      if (data_.update_pdr[i].header.len > 0)   { next_update_pdr(); update_pdr(i); }
-      if (data_.update_far[i].header.len > 0)   { next_update_far(); update_far(i); }
-      if (data_.update_urr[i].header.len > 0)   { next_update_urr(); update_urr(i); }
-      if (data_.update_qer[i].header.len > 0)   { next_update_qer(); update_qer(i); }
-      if (data_.query_urr[i].header.len > 0)    { next_query_urr(); query_urr(i); }
-   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -11385,6 +11450,11 @@ inline int SessionModificationRsp::next_usage_report()
 {
    return (data_.usage_report_count < MAX_LIST_SIZE) ?
       data_.usage_report_count++ : -1;
+}
+
+inline uint8_t SessionModificationRsp::usage_report_count() const
+{
+   return data_.usage_report_count;
 }
 
 inline SessionModificationRsp &SessionModificationRsp::encode(uint8_t *dest)
@@ -11506,6 +11576,11 @@ inline int SessionDeletionRsp::next_usage_report()
       data_.usage_report_count++ : -1;
 }
 
+inline uint8_t SessionDeletionRsp::usage_report_count() const
+{
+   return data_.usage_report_count;
+}
+
 inline SessionDeletionRsp &SessionDeletionRsp::encode(uint8_t *dest)
 {
    data_.header.seid_seqno.has_seid.seq_no = req()->seqNbr();
@@ -11527,11 +11602,6 @@ inline Void SessionDeletionRsp::postDecode()
    if (data_.offending_ie.header.len > 0)             offending_ie(True);
    if (data_.load_ctl_info.header.len > 0)            load_ctl_info(True);
    if (data_.ovrld_ctl_info.header.len > 0)           ovrld_ctl_info(True);
-
-   for (int i=0; i<MAX_LIST_SIZE; i++)
-   {
-      if (data_.usage_report[i].header.len > 0) { next_usage_report(); usage_report(i); }
-   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -11609,6 +11679,11 @@ inline int SessionReportReq::next_usage_report()
       data_.usage_report_count++ : -1;
 }
 
+inline uint8_t SessionReportReq::usage_report_count() const
+{
+   return data_.usage_report_count;
+}
+
 inline SessionReportReq &SessionReportReq::encode(uint8_t *dest)
 {
    data_.header.seid_seqno.has_seid.seq_no = seqNbr();
@@ -11632,11 +11707,6 @@ inline Void SessionReportReq::postDecode()
    if (data_.load_ctl_info.header.len > 0)            load_ctl_info(True);
    if (data_.ovrld_ctl_info.header.len > 0)           ovrld_ctl_info(True);
    if (data_.add_usage_rpts_info.header.len > 0)      add_usage_rpts_info(True);
-
-   for (int i=0; i<MAX_LIST_SIZE; i++)
-   {
-      if (data_.usage_report[i].header.len > 0)   { next_usage_report(); usage_report(i); }
-   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/pfcp/pfcptest/Makefile.am
+++ b/pfcp/pfcptest/Makefile.am
@@ -31,11 +31,12 @@ pfcptest_DEPENDENCIES = \
    $(top_builddir)/src/libpfcpr15.a
 
 # Sources for pfcptest
-pfcptest_SOURCES =     \
-   main.cpp            \
-   pcpp.cpp            \
-   test.cpp            \
-   pcaps/pcaps.cpp     \
+pfcptest_SOURCES =       \
+   main.cpp              \
+   pcpp.cpp              \
+   test.cpp              \
+   analysis/analysis.cpp \
+   pcaps/pcaps.cpp       \
    wrapper/wrapper.cpp
 
 # Compiler options. Here we are adding the include directory

--- a/pfcp/pfcptest/analysis/analysis.cpp
+++ b/pfcp/pfcptest/analysis/analysis.cpp
@@ -1,0 +1,221 @@
+/*
+* Copyright (c) 2020 T-Mobile
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include <map>
+
+#include "pfcpr15inl.h"
+#include "epctools.h"
+#include "eutil.h"
+#include "ejsonbuilder.h"
+
+#include "pcpp.h"
+#include "test.h"
+
+#define PUSH_PACKET_INFO()                                                                   \
+   EJsonBuilder::StackObject pushPacket(json);                                               \
+   EJsonBuilder::StackUInt pushPacketNumber(json, packetNumber, "packet_number");            \
+   EJsonBuilder::StackUInt pushSeqNum(json, appMsg->seqNbr(), "seq_num");
+
+#define PUSH_MSG_INFO(msg)                                                                   \
+   EJsonBuilder::StackString pushMsgName(json, #msg, "msg_name");
+
+#define PUSH_SEID()                                                                          \
+   EJsonBuilder::StackULongLong pushSeid(json, seid, "seid");                     
+
+// This variant uses pdr_id().rule_id() to get the value
+#define PUSH_IES1(msg, action, type)                                                         \
+{                                                                                            \
+   EJsonBuilder::StackArray push_##action##_##type(json, #action "_" #type);                 \
+   for (uint8_t idx = 0u; idx < msg.action##_##type##_count(); ++idx)                        \
+   {                                                                                         \
+      auto &ie = msg.action##_##type(idx);                                                   \
+      EJsonBuilder::StackObject pushIE(json);                                                \
+      EJsonBuilder::StackUInt pushIEId(json, ie.type##_id().rule_id(), #type "_id");         \
+   }                                                                                         \
+}
+
+// This variant uses far_id().far_id_value() to get the value
+#define PUSH_IES2(msg, action, type)                                                         \
+{                                                                                            \
+   EJsonBuilder::StackArray push_##action##_##type(json, #action "_" #type);                 \
+   for (uint8_t idx = 0u; idx < msg.action##_##type##_count(); ++idx)                        \
+   {                                                                                         \
+      auto &ie = msg.action##_##type(idx);                                                   \
+      EJsonBuilder::StackObject pushIE(json);                                                \
+      EJsonBuilder::StackUInt pushIEId(json, ie.type##_id().type##_id_value(), #type "_id"); \
+   }                                                                                         \
+}
+
+namespace PFCPTest
+{
+   namespace analysis
+   {
+      // This function decodes all the pfcp messages in each pcap in the analysis/pcaps
+      // folder and creates output json files with basic information for further analysis
+      TEST(analysis_pcaps)
+      {
+         EString pcapsPath = "./analysis/pcaps";
+
+         // Load pcap tests from disk
+         std::set<EString> pcapFiles;
+         {
+            EDirectory pcapsDir;
+            cpStr pcapFile = pcapsDir.getFirstEntry(pcapsPath, "*.pcap");
+            while (pcapFile)
+            {
+               pcapFiles.emplace(pcapFile);
+               pcapFile = pcapsDir.getNextEntry();
+            }
+         }
+
+         // Remove previous results from the pcaps folder
+         {
+            EDirectory pcapsDir;
+            cpStr jsonFile = pcapsDir.getFirstEntry(pcapsPath, "*.json");
+            while (jsonFile)
+            {
+               EString filePath;
+               EPath::combine(pcapsPath, jsonFile, filePath);
+               if (!EUtility::delete_file(filePath))
+                  ELogger::log(LOG_TEST).minor("Couldn't remove file {}", filePath);
+               jsonFile = pcapsDir.getNextEntry();
+            }
+         }
+
+         // Generate json for each pcap
+         for (auto pcapFile : pcapFiles)
+         {
+            EString pcapPath;
+            EPath::combine(pcapsPath, pcapFile, pcapPath);
+
+            EJsonBuilder json;
+            {
+               EJsonBuilder::StackArray pushPackets(json, "packets");
+
+               pcpp::RawPacketVector rawPackets = GetPackets(pcapPath);
+               int packetNumber = 1;
+               for (auto rawPacket : rawPackets)
+               {
+                  pcpp::Packet packet(rawPacket);
+
+                  std::vector<uint8_t> payload = ExtractPFCPPayload(packet);
+                  std::unique_ptr<PFCP::AppMsg> appMsg = DecodeAppMsg(payload);
+                  if (!appMsg)
+                  {
+                     ELogger::log(LOG_TEST).major("Unhandled PFCP message type in packet {}", packetNumber);
+                     ++packetNumber;
+                     continue;
+                  }
+
+                  switch (appMsg.get()->msgType())
+                  {
+                     case PFCP_SESS_ESTAB_REQ:
+                     {
+                        PFCP_R15::SessionEstablishmentReq &sessEstReq = *(static_cast<PFCP_R15::SessionEstablishmentReq *>(appMsg.get()));
+                        PUSH_PACKET_INFO()
+                        PUSH_MSG_INFO(sess_est_req)
+
+                        auto seid = sessEstReq.cp_fseid().seid();
+                        PUSH_SEID()
+
+                        PUSH_IES1(sessEstReq, create, pdr)
+                        PUSH_IES2(sessEstReq, create, far)
+                        PUSH_IES2(sessEstReq, create, urr)
+                        PUSH_IES2(sessEstReq, create, qer)
+
+                        break;
+                     }
+                     case PFCP_SESS_ESTAB_RSP:
+                     {
+                        PFCP_R15::SessionEstablishmentRsp &sessEstRsp = *(static_cast<PFCP_R15::SessionEstablishmentRsp *>(appMsg.get()));
+                        PUSH_PACKET_INFO()
+                        PUSH_MSG_INFO(sess_est_rsp)
+                        
+                        auto seid = sessEstRsp.up_fseid().seid();
+                        PUSH_SEID()
+
+                        break;
+                     }
+                     case PFCP_SESS_MOD_REQ:
+                     {
+                        PFCP_R15::SessionModificationReq &sessModReq = *(static_cast<PFCP_R15::SessionModificationReq *>(appMsg.get()));
+                        PUSH_PACKET_INFO()
+                        PUSH_MSG_INFO(sess_mod_req)
+
+                        auto seid = sessModReq.session()->localSeid();
+                        PUSH_SEID()
+
+                        PUSH_IES1(sessModReq, update, pdr)
+                        PUSH_IES2(sessModReq, update, far)
+                        PUSH_IES2(sessModReq, update, urr)
+                        PUSH_IES2(sessModReq, update, qer)
+                        PUSH_IES1(sessModReq, create, pdr)
+                        PUSH_IES2(sessModReq, create, far)
+                        PUSH_IES2(sessModReq, create, urr)
+                        PUSH_IES2(sessModReq, create, qer)
+                        PUSH_IES1(sessModReq, remove, pdr)
+                        PUSH_IES2(sessModReq, remove, far)
+                        PUSH_IES2(sessModReq, remove, urr)
+                        PUSH_IES2(sessModReq, remove, qer)
+
+                        break;
+                     }
+                     case PFCP_SESS_MOD_RSP:
+                     {
+                        PFCP_R15::SessionModificationRsp &sessModRsp = *(static_cast<PFCP_R15::SessionModificationRsp *>(appMsg.get()));
+                        PUSH_PACKET_INFO()
+                        PUSH_MSG_INFO(sess_mod_rsp)
+                        auto seid = sessModRsp.req()->session()->localSeid();
+                        PUSH_SEID()
+                        break;
+                     }
+                     case PFCP_SESS_DEL_REQ:
+                     {
+                        PFCP_R15::SessionDeletionReq &sessDelReq = *(static_cast<PFCP_R15::SessionDeletionReq *>(appMsg.get()));
+                        PUSH_PACKET_INFO()
+                        PUSH_MSG_INFO(sess_del_req)
+                        auto seid = sessDelReq.session()->localSeid();
+                        PUSH_SEID()
+                        break;
+                     }
+                     case PFCP_SESS_DEL_RSP:
+                     {
+                        PFCP_R15::SessionDeletionRsp &sessDelRsp = *(static_cast<PFCP_R15::SessionDeletionRsp *>(appMsg.get()));
+                        PUSH_PACKET_INFO()
+                        PUSH_MSG_INFO(sess_del_rsp)
+                        auto seid = sessDelRsp.req()->session()->localSeid();
+                        PUSH_SEID()
+                        break;
+                     }
+                  }
+
+                  ++packetNumber;
+               }
+            }
+
+            EString jsonName = EPath::getFileNameWithoutExtension(pcapFile) + ".json";
+            EString jsonPath;
+            EPath::combine(pcapsPath, jsonName, jsonPath);
+            std::ofstream jsonFile(jsonPath, std::ios_base::trunc);
+            if (jsonFile)
+               jsonFile << json.toString() << std::endl;
+            jsonFile.close();
+         }
+
+         return true;
+      }
+   } // namespace analysis
+} // namespace PFCPTest

--- a/pfcp/pfcptest/analysis/pfcp-analysis.py
+++ b/pfcp/pfcptest/analysis/pfcp-analysis.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+
+# This python script will take a .json file created by the analysis test in pfcptest
+# and output .csv files containing statistics about the pfcp messages.
+#
+# Example usage:
+#  python3 pfcp-analysis.py --file pcaps/n4_interface_capture.json --outdir out
+
+import argparse
+import json
+import time
+import os
+import csv
+
+ies = [
+    'create_pdr', 
+    'create_far', 
+    'create_urr', 
+    'create_qer', 
+    'update_pdr',
+    'update_far',
+    'update_urr',
+    'update_qer',
+    'remove_pdr',
+    'remove_far',
+    'remove_urr',
+    'remove_qer',
+    'create_bar',
+    'update_bar',
+    'remove_bar']
+
+sessions = {}
+seq_num_lookup = {}
+
+# Process all the packets in the pcap
+def processPcap(pcap_file):
+    global seq_num_lookup
+
+    with open(args.file) as f:
+        cap = json.load(f)
+
+    for packet in cap['packets']:
+        seq_num = packet['seq_num']
+        packet_number = packet['packet_number']
+        msg_name = packet['msg_name']
+
+        if 'req' in msg_name:
+            if seq_num in seq_num_lookup:
+                print(f"Error: packet {packet_number} duplicate sequence number")
+            else:
+                seq_num_lookup[seq_num] = packet
+        elif 'rsp' in msg_name:
+            if not seq_num in seq_num_lookup:
+                print(f"Error: packet {packet_number} missing sequence number")
+            else:
+                packet['req'] = seq_num_lookup[seq_num]
+                seq_num_lookup[seq_num]['rsp'] = packet
+                del seq_num_lookup[seq_num]
+
+            # in cp_seid, up_seid order
+            if 'est' in msg_name:
+                session = (packet['req']['seid'], packet['seid'])
+            else:
+                session = (packet['seid'], packet['req']['seid'])
+
+            if not session in sessions:
+                sessions[session] = []
+
+            sessions[session].append(packet)
+
+    for packet in seq_num_lookup:
+        print(f"Missing response for packet {packet['packet_number']}")
+
+def writeSessionsDetailsCsv():
+    global ies
+    global sessions
+
+    sessions_csv = os.path.join(outpath, 'sessions_details.csv')
+    with open(sessions_csv, 'w', newline='') as file:
+        csvwriter = csv.writer(file, dialect=csv.excel)
+
+        headers = []
+        headers.append('cp_seid')
+        headers.append('up_seid')
+        headers.append('message')
+        headers.append('ie')
+        headers.append('id')
+        headers.append('packet_number')
+        csvwriter.writerow(headers)
+
+        for session, packets in sessions.items():
+            for packet in packets:
+                req = packet['req']
+
+                for ie_name in ies:
+                    if not ie_name in req:
+                        continue
+
+                    ie_type = ie_name.split('_')[1]
+
+                    for ie in req[ie_name]:
+                        values = []
+                        values.append(f"{session[0]:#0{18}x}")
+                        values.append(f"{session[1]:#0{18}x}")
+                        values.append(req['msg_name'])
+                        values.append(ie_name)
+                        values.append(ie[f"{ie_type}_id"])
+                        values.append(req['packet_number'])
+                        csvwriter.writerow(values)
+
+def writeSessionsActivityCsv():
+    global ies
+    global sessions
+
+    sessions_csv = os.path.join(outpath, 'sessions_activity.csv')
+    with open(sessions_csv, 'w', newline='') as file:
+        csvwriter = csv.writer(file, dialect=csv.excel)
+
+        ie_types = ['pdr', 'far', 'urr', 'qer', 'bar']
+
+        headers = []
+        headers.append('cp_seid')
+        headers.append('up_seid')
+        headers.append('session_est_req')
+        headers.append('session_del_rsp')
+        for ie_type in ie_types:
+            headers.append(f"max_active_{ie_type}")
+        headers.append('packet_filter')
+        csvwriter.writerow(headers)
+
+        for session, packets in sessions.items():
+            session_est_req = False
+            session_del_rsp = False
+            packet_numbers = []
+            active_sets = {}
+            max_actives = {}
+            for ie_type in ie_types:
+                active_sets[ie_type] = {}
+                max_actives[ie_type] = 0
+
+            for packet in packets:
+                req = packet['req']
+
+                if req['msg_name'] == 'sess_est_req':
+                    session_est_req = True
+
+                if packet['msg_name'] == 'sess_del_rsp':
+                    session_del_rsp = True
+                
+                packet_numbers.append(req['packet_number'])
+                packet_numbers.append(packet['packet_number'])
+
+                for ie_name in ies:
+                    if not ie_name in req:
+                        continue
+
+                    ie_activity = ie_name.split('_')[0]
+                    ie_type = ie_name.split('_')[1]
+
+                    for ie in req[ie_name]:
+                        ie_id = ie[f"{ie_type}_id"]
+
+                        active_set = active_sets[ie_type]
+
+                        if ie_activity == 'create':
+                            active_set[ie_id] = ie_id
+                        elif ie_activity == 'remove':
+                            if ie_id in active_set:
+                                del active_set[ie_id]
+
+                for ie_type in ie_types:
+                    if len(active_sets[ie_type]) > max_actives[ie_type]:
+                        max_actives[ie_type] = len(active_sets[ie_type])
+                                
+
+            values = []
+            values.append(f"{session[0]:#0{18}x}")
+            values.append(f"{session[1]:#0{18}x}")
+            values.append(session_est_req)
+            values.append(session_del_rsp)
+            for ie_type in ie_types:
+                values.append(max_actives[ie_type])
+            packet_filter = 'frame.number in { '
+            for packet_number in packet_numbers:
+                packet_filter += f"{packet_number} "
+            packet_filter += '}'
+            values.append(packet_filter)
+            csvwriter.writerow(values)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Open a pcap file and gathers PFCP stats')
+    parser.add_argument('--file', dest='file', action='store', help='A pcap file')
+    parser.add_argument('--outdir', dest='outdir', action='store', help='Output directory')
+    args = parser.parse_args()
+
+    processPcap(args.file)
+
+    # Create outpath
+    outpath = os.path.join(args.outdir, os.path.splitext(args.file)[0])
+    if not os.path.exists(outpath):
+        os.makedirs(outpath)
+
+    writeSessionsDetailsCsv()
+    writeSessionsActivityCsv()

--- a/pfcp/pfcptest/pcpp.cpp
+++ b/pfcp/pfcptest/pcpp.cpp
@@ -34,6 +34,7 @@ namespace PFCPTest
    PFCP_R15::Translator &GetTranslator()
    {
       static PFCP_R15::Translator trans;
+      PFCP::Configuration::setTranslator(trans);
       return trans;
    }
 

--- a/src/ejsonbuilder.cpp
+++ b/src/ejsonbuilder.cpp
@@ -32,6 +32,7 @@ public:
    Void push(ContainerType type);
    Void push(const EString &value);
    Void push(UInt value);
+   Void push(ULongLong value);
    Void push(Bool value);
    Void pop(const EString &name = "");
    cpStr toString(bool pretty);
@@ -78,6 +79,12 @@ Void EJsonBuilder::Impl::push(const EString &value)
 }
 
 Void EJsonBuilder::Impl::push(UInt value)
+{
+   m_value_stack.emplace_back(value);
+   updateCurrValue();
+}
+
+Void EJsonBuilder::Impl::push(ULongLong value)
 {
    m_value_stack.emplace_back(value);
    updateCurrValue();
@@ -165,6 +172,7 @@ EJsonBuilder::StackValue<T>::StackValue(EJsonBuilder &builder, const T &value, c
 
 // Explicit Instantiations
 template class EJsonBuilder::StackValue<UInt>;
+template class EJsonBuilder::StackValue<ULongLong>;
 template class EJsonBuilder::StackValue<EString>;
 template class EJsonBuilder::StackValue<Bool>;
 
@@ -197,6 +205,16 @@ Void EJsonBuilder::push(const EString &value)
 }
 
 Void EJsonBuilder::push(UInt value)
+{
+   impl().push(value);
+}
+
+Void EJsonBuilder::push(ULongLong value)
+{
+   impl().push(value);
+}
+
+Void EJsonBuilder::push(Bool value)
 {
    impl().push(value);
 }


### PR DESCRIPTION
- Adds a new test which converts pcaps to json representation for python processing
- Adds 64-bit support to EJsonBuilder
- Fixes the translator in pcpp utility
- Fixes a bug with the pfcp wrapper classes calculating the wrong IE counts. The pfcp
  library was decoding them correctly, but the wrapper classes in postDecode() would
  call next_*() methods which would further update the counts.
- Adds helper methods to retrieve IE counts